### PR TITLE
Implement grammar-based response_format handling

### DIFF
--- a/extensions/openai/completions.py
+++ b/extensions/openai/completions.py
@@ -232,6 +232,9 @@ def chat_completions_common(body: dict, is_legacy: bool = False, stream=False, p
         'stream': stream
     })
 
+    if response_schema is not None:
+        generate_params['response_schema'] = response_schema
+
     max_tokens = generate_params['max_new_tokens']
     if max_tokens in [None, 0]:
         generate_params['max_new_tokens'] = 512
@@ -333,6 +336,9 @@ def chat_completions_common(body: dict, is_legacy: bool = False, stream=False, p
             try:
                 cleaned = re.sub(r'^```(?:json)?\n?', '', answer.strip())
                 cleaned = re.sub(r'\n?```$', '', cleaned).strip()
+                match = re.search(r'(\{.*\}|\[.*\])', cleaned, re.DOTALL)
+                if match:
+                    cleaned = match.group(1)
                 parsed = json.loads(cleaned)
                 jsonschema_module.validate(parsed, response_schema)
                 answer = json.dumps(parsed, ensure_ascii=False)

--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -55,6 +55,10 @@ def _generate_reply(question, state, stopping_strings=None, is_chat=False, escap
         state = apply_extensions('state', state)
         question = apply_extensions('input', question, state)
 
+    if state.get('response_schema') and not state.get('grammar_string'):
+        from modules.grammar.grammar_utils import json_schema_to_grammar
+        state['grammar_string'] = json_schema_to_grammar(state.pop('response_schema'))
+
     # Find the stopping strings
     all_stop_strings = []
     for st in (stopping_strings, state['custom_stopping_strings']):


### PR DESCRIPTION
## Summary
- convert JSON schemas to GBNF grammars for structured responses
- apply response_format grammars automatically during text generation
- pass validated response_format schema from OpenAI API to generation state

## Testing
- `pytest` *(fails: RuntimeError: It looks like there is no internet connection and the repo could not be found in the cache (/root/.cache/torch/hub))*

------
https://chatgpt.com/codex/tasks/task_e_6890ee4638248320a79b20e4eb4a09c4